### PR TITLE
Add landing page and pass userId through chat API

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -30,10 +30,9 @@ export async function POST(request: Request) {
   //   return new ChatSDKError('bad_request:api').toResponse();
   // }
 
-  const session = await auth();
-  if (!session?.user) {
-    console.log("Session error");
-    return new ChatSDKError('unauthorized:chat').toResponse();
+  const userId: string | undefined = json['userId'];
+  if (!userId) {
+    return new ChatSDKError('bad_request:api').toResponse();
   }
 
   // const { id, message, selectedVisibilityType } = body;
@@ -47,7 +46,7 @@ export async function POST(request: Request) {
   if (!chat) {
     await saveChat({
       id,
-      userId: session.user.id,
+      userId,
       title: (message.parts?.[0] as any)?.text || 'Chat',
       visibility: selectedVisibilityType as VisibilityType,
     });
@@ -75,7 +74,7 @@ export async function POST(request: Request) {
       const res = await fetch(`${backendUrl}/insertUserMessageForMarvin`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ chatId: id, myStudioSessionId : "1234" , "userId" : "11", message }),
+        body: JSON.stringify({ chatId: id, myStudioSessionId: '1234', userId, message }),
       });
       if (!res.ok) {
         console.error('Local backend responded with', res.status);
@@ -106,15 +105,14 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const chatId = searchParams.get('chatId');
   const after = searchParams.get('after');
+  const userId = searchParams.get('userId');
 
   if (!chatId) {
     return new ChatSDKError('bad_request:api').toResponse();
   }
 
-  const session = await auth();
-  if (!session?.user) {
-    console.log("Session issue");
-    return new ChatSDKError('unauthorized:chat').toResponse();
+  if (!userId) {
+    return new ChatSDKError('bad_request:api').toResponse();
   }
 
   const chat = await getChatById({ id: chatId });
@@ -123,7 +121,7 @@ export async function GET(request: Request) {
     return new ChatSDKError('not_found:chat').toResponse();
   }
 
-  if (chat.visibility === 'private' && chat.userId !== session.user.id) {
+  if (chat.visibility === 'private' && chat.userId !== userId) {
     console.log("private issue");
     return new ChatSDKError('forbidden:chat').toResponse();
   }
@@ -136,7 +134,7 @@ export async function GET(request: Request) {
       url.searchParams.set('chatId', chatId);
       if (after) url.searchParams.set('after', after);
       url.searchParams.set('myStudioSessionId', '1234');
-      url.searchParams.set('userId', '11');
+      url.searchParams.set('userId', userId);
       const res = await fetch(url);
       console.log("Whohooo " + JSON.stringify(res));
       if (res.status === 200) {

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -11,7 +11,6 @@ import type { VisibilityType } from '@/components/visibility-selector';
 import { ChatSDKError } from '@/lib/errors';
 
 export async function POST(request: Request) {
-  console.log("POST Entry call  " + JSON.stringify(request));
   let json;
   try {
     json = await request.json();

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -23,12 +23,11 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
     redirect('/api/auth/guest');
   }
 
-  if (chat.visibility === 'private') {
-    if (!session.user) {
-      return notFound();
-    }
+  const cookieStore = await cookies();
+  const userIdFromCookie = cookieStore.get('userId');
 
-    if (session.user.id !== chat.userId) {
+  if (chat.visibility === 'private') {
+    if (!userIdFromCookie || userIdFromCookie.value !== chat.userId) {
       return notFound();
     }
   }
@@ -50,7 +49,6 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
     }));
   }
 
-  const cookieStore = await cookies();
   const chatModelFromCookie = cookieStore.get('chat-model');
 
   if (!chatModelFromCookie) {
@@ -63,6 +61,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
           initialVisibilityType={chat.visibility}
           isReadonly={session?.user?.id !== chat.userId}
           session={session}
+          userId={userIdFromCookie?.value ?? ''}
           autoResume={true}
         />
       </>
@@ -78,6 +77,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
         session={session}
+        userId={userIdFromCookie?.value ?? ''}
         autoResume={true}
       />
     </>

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -26,6 +26,10 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   const cookieStore = await cookies();
   const userIdFromCookie = cookieStore.get('userId');
 
+  if (!userIdFromCookie || userIdFromCookie.value === '-1') {
+    redirect('/');
+  }
+
   if (chat.visibility === 'private') {
     if (!userIdFromCookie || userIdFromCookie.value !== chat.userId) {
       return notFound();

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
 import { generateUUID } from '@/lib/utils';
-import { auth } from '../(auth)/auth';
+import { auth } from '../../(auth)/auth';
 import { redirect } from 'next/navigation';
 
 export default async function Page() {
@@ -17,6 +17,7 @@ export default async function Page() {
 
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get('chat-model');
+  const userIdFromCookie = cookieStore.get('userId');
 
   if (!modelIdFromCookie) {
     return (
@@ -29,6 +30,7 @@ export default async function Page() {
           initialVisibilityType="private"
           isReadonly={false}
           session={session}
+          userId={userIdFromCookie?.value ?? ''}
           autoResume={false}
         />
       </>
@@ -45,6 +47,7 @@ export default async function Page() {
         initialVisibilityType="private"
         isReadonly={false}
         session={session}
+        userId={userIdFromCookie?.value ?? ''}
         autoResume={false}
       />
     </>

--- a/app/(chat)/chat/page.tsx
+++ b/app/(chat)/chat/page.tsx
@@ -19,6 +19,10 @@ export default async function Page() {
   const modelIdFromCookie = cookieStore.get('chat-model');
   const userIdFromCookie = cookieStore.get('userId');
 
+  if (!userIdFromCookie || userIdFromCookie.value === '-1') {
+    redirect('/');
+  }
+
   if (!modelIdFromCookie) {
     return (
       <>

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -3,6 +3,8 @@ import { DUMMY_PASSWORD } from '@/lib/constants';
 
 export async function POST(request: Request) {
   let body: any;
+  const backendUrl = process.env.LOCAL_BACKEND_URL;
+
   try {
     body = await request.json();
   } catch {
@@ -13,11 +15,24 @@ export async function POST(request: Request) {
   if (!email) {
     return new Response(null, { status: 400 });
   }
-
-  let [user] = await getUser(email);
-  if (!user) {
-    user = await createUser(email, DUMMY_PASSWORD);
+  
+  if (backendUrl) {
+    try {
+      let url = new URL(`${backendUrl}/getUserId`);
+      url.searchParams.set('userEmail', email);
+      const res = await fetch(url);
+      console.log("Whohooo " + JSON.stringify(res));
+      if (res.status === 200) {
+        const data = await res.json();
+        if (data && data.userId && data.userType) {
+          return Response.json({ userId: data.userId, userType : data.userType});
+        }
+      }
+    } catch (error) {
+      console.error('Failed to poll backend', error);
+    }
   }
 
-  return Response.json({ userId: user.id });
+
+ 
 }

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,0 +1,23 @@
+import { getUser, createUser } from '@/lib/db/queries';
+import { DUMMY_PASSWORD } from '@/lib/constants';
+
+export async function POST(request: Request) {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const email = body?.email;
+  if (!email) {
+    return new Response(null, { status: 400 });
+  }
+
+  let [user] = await getUser(email);
+  if (!user) {
+    user = await createUser(email, DUMMY_PASSWORD);
+  }
+
+  return Response.json({ userId: user.id });
+}

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,5 +1,3 @@
-import { getUser, createUser } from '@/lib/db/queries';
-import { DUMMY_PASSWORD } from '@/lib/constants';
 
 export async function POST(request: Request) {
   let body: any;
@@ -24,9 +22,19 @@ export async function POST(request: Request) {
       console.log("Whohooo " + JSON.stringify(res));
       if (res.status === 200) {
         const data = await res.json();
-        if (data && data.userId && data.userType) {
-          return Response.json({ userId: data.userId, userType : data.userType});
+        console.log("Success response from the user api " + JSON.stringify(data));
+        if (data && data.userId) {
+          if (data.userType) {
+            return Response.json({ userId: data.userId, userType : data.userType});
+          } else {
+            return Response.json({userId : data.userId});
+          }
+        } else {
+          return new Response(null, {status : 500});
         }
+      } else {
+        console.log("Failure response from the user api");
+        return new Response(null, {status: 500});
       }
     } catch (error) {
       console.error('Failed to poll backend', error);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,8 +8,8 @@ import { SessionProvider } from 'next-auth/react';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://chat.vercel.ai'),
-  title: 'Next.js Chatbot Template',
-  description: 'Next.js chatbot template using the AI SDK.',
+  title: 'Marvin',
+  description: 'Marvin',
 };
 
 export const viewport = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -10,6 +10,21 @@ export default function Page() {
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
+
+  useEffect(() => {
+    const cookies = document.cookie.split(';').reduce<Record<string, string>>((acc, c) => {
+      const [key, value] = c.trim().split('=');
+      if (key && value) acc[key] = value;
+      return acc;
+    }, {});
+    const cookieUserId = cookies['userId'];
+    const cookieUserType = cookies['userType'];
+    if (cookieUserId && cookieUserType && cookieUserId !== '-1') {
+      localStorage.setItem('userId', cookieUserId);
+      localStorage.setItem('userType', cookieUserType);
+      router.replace('/chat');
+    }
+  }, [router]);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     console.log("handleSubmit - + page.tsx");
@@ -29,7 +44,10 @@ export default function Page() {
         console.log("page.tsx - Got the response from the user api " + JSON.stringify(data));
         console.log(`Response from the user api - ${userId} - ${userType}`);
         if (userId && userId !== '-1') {
-          document.cookie = `userId=${userId};userType=${userType}; path=/`;
+          document.cookie = `userId=${userId}; path=/`;
+          if (userType) {
+            document.cookie = `userType=${userType}; path=/`;
+          }
           localStorage.setItem('userId', userId);
           localStorage.setItem('userType', userType);
           router.push('/chat');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+export default function Page() {
+  const [email, setEmail] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/user', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const userId = data.userId;
+        if (userId) {
+          document.cookie = `userId=${userId}; path=/`;
+          localStorage.setItem('userId', userId);
+          router.push('/chat');
+        }
+      }
+    } catch (err) {
+      console.error('Failed to get user id', err);
+    }
+  }
+
+  return (
+    <div className="flex h-dvh w-screen items-center justify-center bg-background">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-full max-w-md p-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="email" className="text-zinc-600 font-normal dark:text-zinc-400">
+            Email Address
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit">Continue</Button>
+      </form>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,9 +20,11 @@ export default function Page() {
       if (res.ok) {
         const data = await res.json();
         const userId = data.userId;
+        const userType = data.userType;
         if (userId) {
-          document.cookie = `userId=${userId}; path=/`;
+          document.cookie = `userId=${userId};userType=${userType}; path=/`;
           localStorage.setItem('userId', userId);
+          localStorage.setItem('userType', userType);
           router.push('/chat');
         }
       }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,32 +4,43 @@ import { useRouter } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { toast } from '@/components/toast';
 
 export default function Page() {
   const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
   const router = useRouter();
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    console.log("handleSubmit - + page.tsx");
     e.preventDefault();
     try {
+      console.log("page.tsx - making an api call");
       const res = await fetch('/api/user', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       });
+      console.log("page.tsx user api response " + JSON.stringify(res));
       if (res.ok) {
         const data = await res.json();
         const userId = data.userId;
         const userType = data.userType;
-        if (userId) {
+        console.log("page.tsx - Got the response from the user api " + JSON.stringify(data));
+        console.log(`Response from the user api - ${userId} - ${userType}`);
+        if (userId && userId !== '-1') {
           document.cookie = `userId=${userId};userType=${userType}; path=/`;
           localStorage.setItem('userId', userId);
           localStorage.setItem('userType', userType);
           router.push('/chat');
+        } else {
+          setError('Invalid email address');
+          toast({type: 'error', description: 'Invalid email address'});
         }
       }
     } catch (err) {
-      console.error('Failed to get user id', err);
+      setError('Failed to get user id');
+      toast({type: 'error', description: 'Invalid email address'});
     }
   }
 

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -28,7 +28,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
         <SidebarMenu>
           <div className="flex flex-row justify-between items-center">
             <Link
-              href="/"
+              href="/chat"
               onClick={() => {
                 setOpenMobile(false);
               }}
@@ -46,7 +46,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                   className="p-2 h-fit"
                   onClick={() => {
                     setOpenMobile(false);
-                    router.push('/');
+                    router.push('/chat');
                     router.refresh();
                   }}
                 >

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -43,7 +43,7 @@ function PureChatHeader({
               variant="outline"
               className="order-2 md:order-1 md:px-2 px-2 md:h-fit ml-auto md:ml-0"
               onClick={() => {
-                router.push('/');
+                router.push('/chat');
                 router.refresh();
               }}
             >

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -32,6 +32,16 @@ function PureChatHeader({
 
   const { width: windowWidth } = useWindowSize();
 
+  const handleLogout = () => {
+    if (window.confirm('Are you sure you want to sign out?')) {
+      localStorage.removeItem('userId');
+      localStorage.removeItem('userType');
+      document.cookie = 'userId=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      document.cookie = 'userType=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      router.push('/');
+    }
+  };
+
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
@@ -82,6 +92,13 @@ function PureChatHeader({
           <VercelIcon size={16} />
           Deploy with Vercel
         </Link>
+      </Button>
+      <Button
+        variant="outline"
+        className="order-5"
+        onClick={handleLogout}
+      >
+        Logout
       </Button>
     </header>
   );

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -139,7 +139,8 @@ export function Chat({
       experimental_attachments: formattedAttachments,
     };
 
-    append(userMessage);
+    // append(userMessage);
+    setMessages((prev) => [...prev, userMessage]);
 
     setInput('');
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -30,6 +30,7 @@ export function Chat({
   initialVisibilityType,
   isReadonly,
   session,
+  userId,
   autoResume,
 }: {
   id: string;
@@ -38,6 +39,7 @@ export function Chat({
   initialVisibilityType: VisibilityType;
   isReadonly: boolean;
   session: Session;
+  userId: string;
   autoResume: boolean;
 }) {
   const { mutate } = useSWRConfig();
@@ -71,6 +73,7 @@ export function Chat({
       message: body.messages.at(-1),
       selectedChatModel: initialChatModel,
       selectedVisibilityType: visibilityType,
+      userId,
     }),
     onFinish: () => {
       mutate(unstable_serialize(getChatHistoryPaginationKey));
@@ -148,6 +151,7 @@ export function Chat({
           id,
           message: userMessage,
           selectedVisibilityType: visibilityType,
+          userId,
         }),
       });
 
@@ -177,6 +181,7 @@ export function Chat({
   useMessagePolling({
     chatId: id,
     after: pollAfter,
+    userId,
     onMessage: (msg) => {
       setMessages((prev) => [...prev, msg]);
       setPollAfter(null);

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -144,7 +144,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
     setShowDeleteDialog(false);
 
     if (deleteId === id) {
-      router.push('/');
+      router.push('/chat');
     }
   };
 

--- a/hooks/use-message-polling.ts
+++ b/hooks/use-message-polling.ts
@@ -3,16 +3,17 @@ import { useEffect } from 'react';
 export interface UseMessagePollingParams {
   chatId: string;
   after: string | null;
+  userId: string;
   onMessage: (msg: any) => void;
 }
 
-export function useMessagePolling({ chatId, after, onMessage }: UseMessagePollingParams) {
+export function useMessagePolling({ chatId, after, userId, onMessage }: UseMessagePollingParams) {
   useEffect(() => {
     if (!after) return;
     let cancelled = false;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/chat?chatId=${chatId}&after=${after}`);
+        const res = await fetch(`/api/chat?chatId=${chatId}&after=${after}&userId=${userId}`);
         if (res.status === 200) {
           const data = await res.json();
           if (!cancelled) {
@@ -29,5 +30,5 @@ export function useMessagePolling({ chatId, after, onMessage }: UseMessagePollin
       cancelled = true;
       clearInterval(interval);
     };
-  }, [chatId, after, onMessage]);
+  }, [chatId, after, userId, onMessage]);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
   experimental: {
     ppr: true,
   },
+  reactStrictMode : true,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- add simple landing page to request user email
- create `/api/user` route to register user and return userId
- move chat page under `/chat` and pass userId from cookie
- include userId when posting chats and polling messages
- adjust backend chat API to forward userId to local backend
- update navigation links for the new chat route

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685d7fa82bd483339161a50ef351e690