### PR TITLE
Add cookie based auto login and logout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -10,6 +10,21 @@ export default function Page() {
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
+
+  useEffect(() => {
+    const cookies = document.cookie.split(';').reduce<Record<string, string>>((acc, c) => {
+      const [key, value] = c.trim().split('=');
+      if (key && value) acc[key] = value;
+      return acc;
+    }, {});
+    const cookieUserId = cookies['userId'];
+    const cookieUserType = cookies['userType'];
+    if (cookieUserId && cookieUserType && cookieUserId !== '-1') {
+      localStorage.setItem('userId', cookieUserId);
+      localStorage.setItem('userType', cookieUserType);
+      router.replace('/chat');
+    }
+  }, [router]);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     console.log("handleSubmit - + page.tsx");
@@ -29,7 +44,10 @@ export default function Page() {
         console.log("page.tsx - Got the response from the user api " + JSON.stringify(data));
         console.log(`Response from the user api - ${userId} - ${userType}`);
         if (userId && userId !== '-1') {
-          document.cookie = `userId=${userId};userType=${userType}; path=/`;
+          document.cookie = `userId=${userId}; path=/`;
+          if (userType) {
+            document.cookie = `userType=${userType}; path=/`;
+          }
           localStorage.setItem('userId', userId);
           localStorage.setItem('userType', userType);
           router.push('/chat');

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -32,6 +32,16 @@ function PureChatHeader({
 
   const { width: windowWidth } = useWindowSize();
 
+  const handleLogout = () => {
+    if (window.confirm('Are you sure you want to sign out?')) {
+      localStorage.removeItem('userId');
+      localStorage.removeItem('userType');
+      document.cookie = 'userId=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      document.cookie = 'userType=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+      router.push('/');
+    }
+  };
+
   return (
     <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2">
       <SidebarToggle />
@@ -82,6 +92,13 @@ function PureChatHeader({
           <VercelIcon size={16} />
           Deploy with Vercel
         </Link>
+      </Button>
+      <Button
+        variant="outline"
+        className="order-5"
+        onClick={handleLogout}
+      >
+        Logout
       </Button>
     </header>
   );


### PR DESCRIPTION
## Summary
- auto-login to chat page if cookie values exist
- store cookie values in localStorage on entry
- fix cookie setting on login
- add logout button with confirmation

## Testing
- `pnpm exec playwright test` *(fails: E403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6863f945ecc08333aa720104f812ae61